### PR TITLE
Move all Gems out of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ ENV LANG C.UTF-8
 COPY run.sh /usr/local/bin/
 
 ENTRYPOINT ["run.sh"]
-CMD ["--config", "_config.yml,_config_dev.yml"]
+CMD ["serve", "--config", "_config.yml,_config_dev.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ruby:2.3.1
 WORKDIR /usr/src/app
 ENV LANG C.UTF-8
-RUN gem install jekyll
-RUN gem install html-proofer
+
 COPY run.sh /usr/local/bin/
 
 ENTRYPOINT ["run.sh"]

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ docker run --tty --name your_container \
 
 > **Note:** On Windows, append the following arguments:
 > ```bash
-> --config _config.yml,_config_dev.yml --force_polling
+> serve --config _config.yml,_config_dev.yml --force_polling
 > ```

--- a/SampleSite/Gemfile
+++ b/SampleSite/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 3.3"
 gem "minima"
+gem "html-proofer"

--- a/SampleSite/Gemfile.lock
+++ b/SampleSite/Gemfile.lock
@@ -1,11 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
+    colored (1.2)
+    concurrent-ruby (1.0.4)
+    ethon (0.10.1)
+      ffi (>= 1.3.0)
     ffi (1.9.14)
     forwardable-extended (2.6.0)
+    html-proofer (3.4.0)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
+    i18n (0.7.0)
     jekyll (3.3.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -27,8 +46,13 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    mini_portile2 (2.1.0)
     minima (2.1.0)
       jekyll (~> 3.3)
+    minitest (5.10.1)
+    nokogiri (1.7.0.1)
+      mini_portile2 (~> 2.1.0)
+    parallel (1.10.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.4)
@@ -38,11 +62,18 @@ GEM
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
+    thread_safe (0.3.5)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll (~> 3.3)
   minima
 

--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,4 @@ set -x
 bundle install
 jekyll build
 htmlproofer --url-ignore "/feed.xml" ./_site
-jekyll serve "$@"
+jekyll "$@"


### PR DESCRIPTION
It doesn't look like a good design to have Jekyll and other gems installed at image build time. Instead, I should assume that developers specify their own dependencies in their Gemfiles.

This has been especially problematic with Jekyll plugins.