### PR TITLE
HtmlProofer should not stop script execution

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,5 +8,5 @@ set -o nounset
 set -x
 bundle install
 jekyll build
-htmlproofer --url-ignore "/feed.xml" ./_site
+htmlproofer ./_site
 jekyll "$@"

--- a/run.sh
+++ b/run.sh
@@ -8,5 +8,6 @@ set -o nounset
 set -x
 bundle install
 jekyll build
-htmlproofer ./_site
+# Validate HTML, but continue execution even if htmlproofer reports errors
+htmlproofer ./_site || true
 jekyll "$@"


### PR DESCRIPTION
HtmlProofer should just report the HTML validation errors. The script should proceed to serve the site even with the HTML validation errors.